### PR TITLE
Add sub zones endpoint to api

### DIFF
--- a/modules/gmysqlbackend/gmysqlbackend.cc
+++ b/modules/gmysqlbackend/gmysqlbackend.cc
@@ -157,6 +157,7 @@ public:
     declare(suffix, "delete-comments-query", "", "DELETE FROM comments WHERE domain_id=?");
     declare(suffix, "search-records-query", "", record_query+" name LIKE ? OR content LIKE ? LIMIT ?");
     declare(suffix, "search-comments-query", "", "SELECT domain_id,name,type,modified_at,account,comment FROM comments WHERE name LIKE ? OR comment LIKE ? LIMIT ?");
+    declare(suffix, "get-sub-zones-query", "", "SELECT id,name FROM domains WHERE name LIKE ?");
   }
 
   DNSBackend *make(const string &suffix="")

--- a/modules/godbcbackend/godbcbackend.cc
+++ b/modules/godbcbackend/godbcbackend.cc
@@ -143,6 +143,7 @@ public:
     declare(suffix, "delete-comments-query", "", "DELETE FROM comments WHERE domain_id=?");
     declare(suffix, "search-records-query", "", record_query+" name LIKE ? OR content LIKE ? LIMIT ?");
     declare(suffix, "search-comments-query", "", "SELECT domain_id,name,type,modified_at,account,comment FROM comments WHERE name LIKE ? OR comment LIKE ? LIMIT ?");
+    declare(suffix, "get-sub-zones-query", "", "SELECT id,name FROM domains WHERE name LIKE ?");
   }
 
   //! Constructs a new gODBCBackend object.

--- a/modules/gpgsqlbackend/gpgsqlbackend.cc
+++ b/modules/gpgsqlbackend/gpgsqlbackend.cc
@@ -162,6 +162,7 @@ public:
     declare(suffix, "delete-comments-query", "", "DELETE FROM comments WHERE domain_id=$1");
     declare(suffix, "search-records-query", "", record_query+" name LIKE $1 OR content LIKE $2 LIMIT $3");
     declare(suffix, "search-comments-query", "", "SELECT domain_id,name,type,modified_at,account,comment FROM comments WHERE name LIKE $1 OR comment LIKE $2 LIMIT $3");
+    declare(suffix, "get-sub-zones-query", "", "SELECT id,name FROM domains WHERE name LIKE $1");
 
   }
 

--- a/modules/gsqlite3backend/gsqlite3backend.cc
+++ b/modules/gsqlite3backend/gsqlite3backend.cc
@@ -153,6 +153,7 @@ public:
     declare(suffix, "delete-comments-query", "", "DELETE FROM comments WHERE domain_id=:domain_id");
     declare(suffix, "search-records-query", "", record_query+" name LIKE :value OR content LIKE :value2 LIMIT :limit");
     declare(suffix, "search-comments-query", "", "SELECT domain_id,name,type,modified_at,account,comment FROM comments WHERE name LIKE :value OR comment LIKE :value2 LIMIT :limit");
+    declare(suffix, "get-sub-zones-query", "", "SELECT id,name FROM domains WHERE name LIKE :value");
   }
 
   //! Constructs a new gSQLite3Backend object.

--- a/modules/remotebackend/remotebackend.hh
+++ b/modules/remotebackend/remotebackend.hh
@@ -188,6 +188,7 @@ class RemoteBackend : public DNSBackend
   string directBackendCmd(const string& querystr) override;
   bool searchRecords(const string &pattern, int maxResults, vector<DNSResourceRecord>& result) override;
   bool searchComments(const string &pattern, int maxResults, vector<Comment>& result) override;
+  bool getSubZones(const string &pattern, vector<std::tuple<string, string>>& result) override;
   void getAllDomains(vector<DomainInfo> *domains, bool include_disabled=false) override;
   void getUpdatedMasters(vector<DomainInfo>* domains) override;
   void alsoNotifies(const DNSName &domain, set<string> *ips) override;

--- a/pdns/backends/gsql/gsqlbackend.hh
+++ b/pdns/backends/gsql/gsqlbackend.hh
@@ -114,6 +114,7 @@ public:
       d_DeleteCommentsQuery_stmt = d_db->prepare(d_DeleteCommentsQuery, 1);
       d_SearchRecordsQuery_stmt = d_db->prepare(d_SearchRecordsQuery, 3);
       d_SearchCommentsQuery_stmt = d_db->prepare(d_SearchCommentsQuery, 3);
+      d_GetSubZonesQuery_stmt = d_db->prepare(d_GetSubZonesQuery, 1);
     }
   }
 
@@ -177,6 +178,7 @@ public:
     d_DeleteCommentsQuery_stmt.reset();
     d_SearchRecordsQuery_stmt.reset();
     d_SearchCommentsQuery_stmt.reset();
+    d_GetSubZonesQuery_stmt.reset();
   }
 
   void lookup(const QType &, const DNSName &qdomain, int zoneId, DNSPacket *p=nullptr) override;
@@ -237,12 +239,14 @@ public:
   string directBackendCmd(const string &query) override;
   bool searchRecords(const string &pattern, int maxResults, vector<DNSResourceRecord>& result) override;
   bool searchComments(const string &pattern, int maxResults, vector<Comment>& result) override;
+  bool getSubZones(const string &pattern, vector<std::tuple<string, string>>& result) override;
 
 protected:
   bool createDomain(const DNSName &domain, const string &type, const string &masters, const string &account);
   string pattern2SQLPattern(const string& pattern);
   void extractRecord(const SSqlStatement::row_t& row, DNSResourceRecord& rr);
   void extractComment(const SSqlStatement::row_t& row, Comment& c);
+  void extractZoneReference(const SSqlStatement::row_t& row, std::tuple<string, string>& reference);
   bool isConnectionUsable() {
     if (d_db) {
       return d_db->isConnectionUsable();
@@ -341,6 +345,7 @@ private:
 
   string d_SearchRecordsQuery;
   string d_SearchCommentsQuery;
+  string d_GetSubZonesQuery;
 
   unique_ptr<SSqlStatement>* d_query_stmt;
 
@@ -403,6 +408,7 @@ private:
   unique_ptr<SSqlStatement> d_DeleteCommentsQuery_stmt;
   unique_ptr<SSqlStatement> d_SearchRecordsQuery_stmt;
   unique_ptr<SSqlStatement> d_SearchCommentsQuery_stmt;
+  unique_ptr<SSqlStatement> d_GetSubZonesQuery_stmt;
 
 protected:
   std::unique_ptr<SSql> d_db{nullptr};

--- a/pdns/dnsbackend.hh
+++ b/pdns/dnsbackend.hh
@@ -377,6 +377,12 @@ public:
     return false;
   }
 
+  //! Return subzones for a zone, returns true if search was done successfully.
+  virtual bool getSubZones(const string &pattern, vector<std::tuple<string, string>>& result)
+  {
+    return false;
+  }
+
   const string& getPrefix() { return d_prefix; };
 protected:
   bool mustDo(const string &key);

--- a/pdns/ueberbackend.cc
+++ b/pdns/ueberbackend.cc
@@ -676,6 +676,14 @@ bool UeberBackend::searchComments(const string& pattern, int maxResults, vector<
   return rc;
 }
 
+bool UeberBackend::getSubZones(const string& pattern, vector<std::tuple<string, string>>& result)
+{
+  bool rc = false;
+  for ( vector< DNSBackend * >::iterator i = backends.begin(); i != backends.end(); ++i )
+    if ((*i)->getSubZones(pattern, result)) rc = true;
+  return rc;
+}
+
 AtomicCounter UeberBackend::handle::instances(0);
 
 UeberBackend::handle::handle()

--- a/pdns/ueberbackend.hh
+++ b/pdns/ueberbackend.hh
@@ -133,6 +133,7 @@ public:
   void reload();
   bool searchRecords(const string &pattern, int maxResults, vector<DNSResourceRecord>& result);
   bool searchComments(const string &pattern, int maxResults, vector<Comment>& result);
+  bool getSubZones(const string &pattern, vector<std::tuple<string, string>>& result);
 private:
   pthread_t d_tid;
   handle d_handle;

--- a/pdns/ws-auth.cc
+++ b/pdns/ws-auth.cc
@@ -2250,6 +2250,28 @@ static void apiServerSearchData(HttpRequest* req, HttpResponse* resp) {
   resp->setBody(doc);
 }
 
+static void apiServerSubZones(HttpRequest* req, HttpResponse* resp) {
+  if(req->method != "GET")
+    throw HttpMethodNotAllowedException();
+
+  DNSName zonename = apiZoneIdToName(req->parameters["id"]);
+  Json::array doc;
+  vector<std::tuple<string, string>> subZoneResult;
+  UeberBackend B;
+  B.getSubZones(zonename.toStringNoDot(), subZoneResult);
+  for(const std::tuple<string, string> &z: subZoneResult)
+  {
+    auto object = Json::object {
+        { "object_type", "subzone" },
+        { "zone_id", std::get<0>(z) },
+        { "name", std::get<1>(z) }
+      };
+    doc.push_back(object);
+   }
+  resp->setBody(doc);
+}
+
+
 void apiServerCacheFlush(HttpRequest* req, HttpResponse* resp) {
   if(req->method != "PUT")
     throw HttpMethodNotAllowedException();
@@ -2318,6 +2340,7 @@ void AuthWebServer::webThread()
       d_ws->registerApiHandler("/api/v1/servers/localhost/zones/<id>/metadata", &apiZoneMetadata);
       d_ws->registerApiHandler("/api/v1/servers/localhost/zones/<id>/notify", &apiServerZoneNotify);
       d_ws->registerApiHandler("/api/v1/servers/localhost/zones/<id>/rectify", &apiServerZoneRectify);
+      d_ws->registerApiHandler("/api/v1/servers/localhost/zones/<id>/sub-zones", &apiServerSubZones);
       d_ws->registerApiHandler("/api/v1/servers/localhost/zones/<id>", &apiServerZoneDetail);
       d_ws->registerApiHandler("/api/v1/servers/localhost/zones", &apiServerZones);
       d_ws->registerApiHandler("/api/v1/servers/localhost", &apiServerDetail);

--- a/regression-tests.api/test_Zones.py
+++ b/regression-tests.api/test_Zones.py
@@ -2016,6 +2016,20 @@ $ORIGIN %NAME%
         self.assertEquals(r.status_code, 422)
         self.assertIn('A TSIG key with the name', r.json()['error'])
 
+    def test_get_subzones(self):
+        name = unique_zone_name()
+        self.create_zone(name=name)
+        self.create_zone(name='subdomain.'+name)
+        self.create_zone(name='subdomain2.'+name)
+        other_zone_name = unique_zone_name()
+        self.create_zone(name=other_zone_name)
+        r = self.session.get(self.url("/api/v1/servers/localhost/zones/" + name + "/sub-zones"))
+        self.assert_success_json(r)
+        self.assertEquals(len(r.json()), 2)
+        self.assertIn('subdomain', str(r.json()))
+        self.assertIn('subdomain2', str(r.json()))
+        self.assertNotIn(other_zone_name, str(r.json()))
+
 
 @unittest.skipIf(not is_auth(), "Not applicable")
 class AuthRootZone(ApiTestCase, AuthZonesHelperMixin):


### PR DESCRIPTION
### Short description
This PR adds a new endpoint `/zones/<id>/sub-zones`, which returns the names and zone ids for all existing subdomain zones for the selected zone.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [X] added or modified regression test(s)
- [ ] added or modified unit test(s)

